### PR TITLE
Fixed errors + '나가기' 함수, '수학' 모듈 implemented + '랜덤' 모듈 extended

### DIFF
--- a/yaksok/bootbakyi.py
+++ b/yaksok/bootbakyi.py
@@ -42,6 +42,9 @@ def ____subscript(l, x):
 def ____print_one(x):
     print(x)
 
+def ____exit_noprob():
+    exit(0)
+
 def ____find_and_call_function(matcher, lenv, genv, functions, cache={}):
     #key = tuple(x if x[0] != 'EXPR' else ('EXPR', None) for x in matcher), tuple(tuple(x[1]) for x in functions), tuple(sorted(lenv.keys())), tuple(sorted(genv.keys()))
 
@@ -161,4 +164,4 @@ def ____find_and_call_function(matcher, lenv, genv, functions, cache={}):
     return type(func)(func.__code__, genv)(*args)
 
 
-____functions = [(____print_one, [('IDENTIFIER', '값'), ('WS',' '), ('STR', '보여주기')])]
+____functions = [(____print_one, [('IDENTIFIER', '값'), ('WS',' '), ('STR', '보여주기')]), (____exit_noprob,[('STR','나가기')])]

--- a/yaksok/bootbakyi.py
+++ b/yaksok/bootbakyi.py
@@ -24,7 +24,7 @@ def ____getmodule(name):
     # TODO sys.modules 같은 import된 모듈 저장소가 필요
     if name not in ____modules:
         path = ____search_module_file(name)
-        ____modules[name] = ____run_code(open(path).read(), name+'.yak')
+        ____modules[name] = ____run_code(open(path, encoding='UTF8').read(), name+'.yak')
     return ____modules[name]
 
 

--- a/yaksok/modules/랜덤.yak
+++ b/yaksok/modules/랜덤.yak
@@ -4,6 +4,25 @@
     return random.choice(배열)
 ***
 
+번역(python) 이거 요거 "사이에 랜덤 정수 선택하기"
+***
+    import random
+    return random.randint(이거, 요거)
+***
+
+번역(python) 이거 요거 "사이에 랜덤 실수 선택하기"
+***
+    import random
+    return random.uniform(이거, 요거)
+***
+
+번역(python) 배열 "랜덤 섞기"
+***
+    import random
+    random.shuffle(배열)
+    return 배열
+***
+
 번역(javascript) 배열 "랜덤 선택하기"
 ***
     return 배열[Math.floor(Math.random() * 배열.length)];

--- a/yaksok/modules/수학.yak
+++ b/yaksok/modules/수학.yak
@@ -1,0 +1,52 @@
+번역(python) 값 "을 올림"
+***
+    import math
+    return math.ceil(값)
+***
+
+번역(python) 값 "의 절댓값"
+***
+    import math
+    return math.fabs(값)
+***
+
+번역(python) 값 "을 내림"
+***
+    import math
+    return math.floor(값)
+***
+
+번역(python) 아래 "를 밑으로하는" 위 "로그 값"
+***
+    import math
+    return math.log(위, 아래)
+***
+
+번역(python) 값 "에" 몇 "승"
+***
+    import math
+    return math.pow(값, 몇)
+***
+
+번역(python) 값 "의 제곱근"
+***
+    import math
+    return math.sqrt(값)
+***
+
+번역(python) "원주율"
+***
+    import math
+    return math.pi
+***
+
+번역(python) "자연 상수"
+***
+    import math
+    return math.e
+***
+번역(python) "타우"
+***
+    import math
+    return math.tau
+***

--- a/yaksok/yacc.py
+++ b/yaksok/yacc.py
@@ -649,7 +649,7 @@ def p_subscription(t):
     func.lineno = t.lineno(1)
     func.col_offset = -1  # XXX
 
-    t[0] = ast.Call(func, [t[1], index], [], None, None)
+    t[0] = ast.Call(func, [t[1], index], [])#, None, None)
     t[0].lineno = t.lineno(1)
     t[0].col_offset = -1  # XXX
 
@@ -707,7 +707,7 @@ def p_range(t):
     func.lineno = t.lineno(2)
     func.col_offset = -1  # XXX
     add_one = make_add_one(t, 3)
-    t[0] = ast.Call(func, [t[1], add_one], [], None, None)
+    t[0] = ast.Call(func, [t[1], add_one], [])#, None, None)
     t[0].lineno = t.lineno(2)
     t[0].col_offset = -1  # XXX
 

--- a/yaksok/yaksok.py
+++ b/yaksok/yaksok.py
@@ -39,7 +39,7 @@ def main():
         import logging
         logging.basicConfig(level=logging.DEBUG)
     if args.file_name:
-        code = open(args.file_name).read()
+        code = open(args.file_name, encoding='UTF8').read()
         run_code(code, args.file_name)
         return
     while True:


### PR DESCRIPTION
bootbakyi.py, yaksok.py -> 'cp949' codec으로 decoding을 못하는 문제 해결 
yacc.py -> ast.Call 함수 사용법을 현재 Python에 맞게 수정'
'나가기' 구현 -> Python shell의 exit()과 같은 기능으로 exit(0)을 실행함.
'수학' 모듈 구현 -> math module의 ceil, fabs, floor, log, pow, sqrt, pi, e, tau 구현
'랜덤' 모듈 확장 -> random module의 randint, uniform, shuffle 구현 